### PR TITLE
sorted sql query by date

### DIFF
--- a/hrapp/views/trainingprograms/training_program_list.py
+++ b/hrapp/views/trainingprograms/training_program_list.py
@@ -1,11 +1,14 @@
 import sqlite3
+import datetime
 from django.shortcuts import render
 from hrapp.models import TrainingProgram
 from ..connection import Connection
 
+
 def training_program_list(request):
     with sqlite3.connect(Connection.db_path) as conn:
         conn.row_factory = sqlite3.Row
+        
 
         db_cursor = conn.cursor()
         db_cursor.execute(
@@ -17,6 +20,7 @@ def training_program_list(request):
             tp.end_date, 
             tp.capacity
             FROM hrapp_trainingprogram tp
+            WHERE tp.start_date > date()
             """
         )
 


### PR DESCRIPTION
# Description
Filtering SQL query by future date - list view now only displays trainings that have not started yet

Relates to issue # 11

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Testing Instructions

git fetch --all
git checkout sort-program-date
python manage.py runserver

### Testing Steps
1. Navigate to Training Programs
2. Ensure that only future programs are displayed
3. Make sure nothing else breaks

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
